### PR TITLE
AEM improvements 

### DIFF
--- a/srv/configure.js
+++ b/srv/configure.js
@@ -29,6 +29,19 @@ const directivesWatcher = chokidar.watch(directivePath)
 const assetsWatcher = chokidar.watch(assetsPath)
 const stylesWatcher = chokidar.watch(stylePath)
 
+if (aemMocksPath) {
+  const aemMocksWatcher = chokidar.watch(aemMocksPath)
+
+  aemMocksWatcher.on('ready', function () {
+    aemMocksWatcher.on('all', function (event, file) {
+      // Make sure the mock files are not cached when rendering HTL.
+      // This watcher does not trigger a rebuild, so after editing a 
+      // mock file the corresponding component needs to be saved manually.
+      delete require.cache[file]
+    })
+  })
+}
+
 componentsWatcher.on('ready', function () {
   componentsWatcher.on('all', function () {
     console.log('rebuild components')

--- a/srv/service.js
+++ b/srv/service.js
@@ -108,7 +108,8 @@ module.exports = function (pathToComponents, pathToPages, pathToAemMocks, backen
               notifications.push({ text: 'meta.js file not found' })
             }
           } catch (e) {
-            errors.push({ text: e })
+            console.log(e)
+            errors.push({ text: e.toString() })
           }
         }
 


### PR DESCRIPTION
- The error message for missing mocks wasn't very helpful since it just showed `MODULE_NOT_FOUND` without telling me the failing path. Transforming the error to a string resulted in a more usable output for me.
- I had to restart the server after changing mock files since `@adobe/htlengine` would pick up the cached ones: https://github.com/adobe/htlengine/blob/0d6883578acd7c4e509dee8d43c841775148b0ca/src/runtime/Runtime.js#L110