### PR TITLE
Toggle fullscreen demo mode with option+F

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" class="columns">
+  <div id="app" class="columns" :class="{ 'is-fullscreen-demo': isFullscreenDemo }">
     <div class="column is-narrow">
       <aside class="menu">
         <router-link :to="'/'"><img class="menu-image" :src="logo"></router-link>
@@ -37,7 +37,8 @@ export default {
   data () {
     return {
       logo,
-      navigation: {}
+      navigation: {},
+      isFullscreenDemo: false
     }
   },
 
@@ -47,6 +48,12 @@ export default {
       .then(res => {
         this.navigation = res
       })
+
+    document.addEventListener('keydown', (event) => {
+      if (event.altKey && event.which === 70) {
+        this.isFullscreenDemo = !this.isFullscreenDemo
+      }
+    })
   },
 
   computed: {

--- a/src/components/ComponentView.vue
+++ b/src/components/ComponentView.vue
@@ -243,10 +243,10 @@ export default {
 
 .is-fullscreen-demo .tabs-content {
   position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: #fff;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #fff;
 }
 </style>

--- a/src/components/ComponentView.vue
+++ b/src/components/ComponentView.vue
@@ -240,4 +240,13 @@ export default {
 .dropdown-item {
   text-transform: capitalize;
 }
+
+.is-fullscreen-demo .tabs-content {
+  position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #fff;
+}
 </style>


### PR DESCRIPTION
This change adds the possibility to use <kbd>option+F</kbd> to toggle a fullscreen mode. The current tab will be blown up to cover the screen. This simplifies previewing full-width as the sidebar is currently pushing the content to the side. 