### PR TITLE
Fix IE build

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import 'whatwg-fetch'
 import App from '@/components/App.vue'
 import router from '@/router'
 import '../dist/allComponents'

--- a/vue.config.js
+++ b/vue.config.js
@@ -35,6 +35,8 @@ module.exports = {
       .set('@assets', assetsPath)
   },
 
+  transpileDependencies: ['ic-fe-blueprint'],
+
   css: {
     sourceMap: true,
     loaderOptions: {


### PR DESCRIPTION
In order for the build to work in IE, I had to add the package itself to `transpileDependencies` (since this config is requested from the parent package) as well as a polyfill for `fetch`.