### PR TITLE
Add resource directory

### DIFF
--- a/srv/htl/template.js
+++ b/srv/htl/template.js
@@ -40,6 +40,7 @@ module.exports.main = async function main(resource, config) {
   const runtime = new ICRuntime(config.useOptions);
   runtime.setGlobal(resource);
   runtime.withUseDirectory(config.useDir);
+  runtime.withResourceDirectory(config.useDir);
   await run(runtime);
   return {
     body: runtime.stream


### PR DESCRIPTION
This change allows to the use of `data-sly-resource` directives. The resources will be looked for in `aemMocks`.