### PR TITLE
Initialize for vue components in raw html

### DIFF
--- a/src/components/ComponentView.vue
+++ b/src/components/ComponentView.vue
@@ -94,7 +94,7 @@
         </template>
 
         <template v-else-if="activeTab === 'raw'">
-          <div v-html="data.raw" />
+          <component :is="insertRaw(data.raw)"/>
         </template>
         <template v-else-if="activeTab === 'notifications'">
             <ul>
@@ -217,7 +217,13 @@ export default {
       window.setTimeout(() => {
         this[`copied${pos}`] = false
       }, 2500)
-    }
+    },
+
+    insertRaw (template) {
+      return {
+        template
+      }
+    },
   }
 }
 </script>

--- a/vue.config.js
+++ b/vue.config.js
@@ -36,6 +36,7 @@ module.exports = {
   },
 
   transpileDependencies: ['ic-fe-blueprint'],
+  runtimeCompiler: true,
 
   css: {
     sourceMap: true,


### PR DESCRIPTION
This change allows for the use of Vue components in HTL/Sightly templates. When rendering the `HTL` tab, its content will not just be statically inserted but rather compiled by Vue. For this to work, I had to add `runtimeCompiler` to the Vue config.