### PR TITLE
Trigger DOMContentLoaded after inserting markup

### DIFF
--- a/src/components/ComponentView.vue
+++ b/src/components/ComponentView.vue
@@ -208,6 +208,8 @@ export default {
         .then(res => {
           this.data = res
           this.component = res.cmsOnly ? false : componentName
+
+          document.dispatchEvent(new Event('DOMContentLoaded'))
         })
     },
 


### PR DESCRIPTION
This change allows us to use `document.addEventListener('DOMContentLoaded')` in `static.js` and have its code run after static HTML was inserted by Blueprint.