### PR TITLE
Add MDN polyfills for IE compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "handlebars": "^4.1.0",
     "lowdb": "^1.0.0",
     "marked": "^0.6.1",
+    "mdn-polyfills": "^5.18.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "raw-loader": "^1.0.0",

--- a/src/components/ComponentView.vue
+++ b/src/components/ComponentView.vue
@@ -123,6 +123,7 @@
 import Vue from 'vue'
 import VueMarkdown from 'vue-markdown'
 import VueClipboard from 'vue-clipboard2'
+import 'mdn-polyfills/CustomEvent'
 
 Vue.use(VueClipboard)
 
@@ -210,7 +211,7 @@ export default {
           this.component = res.cmsOnly ? false : componentName
 
           Vue.nextTick(() => {
-            document.dispatchEvent(new Event('DOMContentLoaded'))
+            document.dispatchEvent(new CustomEvent('DOMContentLoaded'))
           })
         })
     },


### PR DESCRIPTION
The previous approach of triggering `DOMContentLoaded` was throwing in IE11