### PR TITLE
Allow for configuration of transpileDependencies

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -8,6 +8,7 @@ const rootPath = defineRootPath(args.embedded)
 const componentsPath = definePath(args.componentsPath, rootPath, config.components)
 const pagesPath = definePath(args.pagesPath, rootPath, config.pages)
 const assetsPath = definePath(args.assetsPath, rootPath, config.assets)
+const transpileDependencies = args.transpileDependencies && !Array.isArray(args.transpileDependencies) ? [args.transpileDependencies] : args.transpileDependencies
 
 module.exports = {
   devServer: {
@@ -35,7 +36,7 @@ module.exports = {
       .set('@assets', assetsPath)
   },
 
-  transpileDependencies: ['ic-fe-blueprint'],
+  transpileDependencies: ['ic-fe-blueprint'].concat(transpileDependencies || []),
   runtimeCompiler: true,
 
   css: {


### PR DESCRIPTION
We need to be able to extend `transpileDependencies` in Blueprint's Vue config if we have dependencies in `node_modules` we want to have transpiled.

This change will allow us to change the npm script triggering Blueprint with an `transpileDependencies` argument. 

Example where `vue-a11y-calendar` would be transpiled with Babel:
```json
"scripts": {
    "blueprint": "npm run blueprint:distwatch & npm explore ic-fe-blueprint -- npm run localserve -- --embedded --backendTemplates=htl --transpileDependencies=vue-a11y-calendar && kill $!"
}
```

Independent of this, the project's `vue.config.js` needs to be extended as well:
```js
{
  // ...
  transpileDependencies: ['vue-a11y-calendar']
}
```